### PR TITLE
added ordering for comment count - that sucked!

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -13,7 +13,7 @@ def get_user_profile(request, username):
 
 def index(request):
     """Index View"""
-    postlinks = PostLink.objects.all()
+    PostLink.objects.all().annotate(num_comments=Count('comment')).order_by('-num_comments', '-created_at')
     num_postlinks = PostLink.objects.all().count()
 
     context = {


### PR DESCRIPTION
I added an ordering feature on the index view to order by count and then by date. I tried to recreate what Clinton did with his busy b application, but I did not want to have to rewrite the index page and create a new template. I found an article on stackoverflow that showed me how we can use annotate on the index view and then order by. I was trying to create a function inside the view, but that failed miserably. 